### PR TITLE
PCHR-2387: Update Makefile to Install views_fieldsets v2.1

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -132,7 +132,7 @@ projects[download][subdir] = civihr-contrib-required
 projects[download][version] = "2.5"
 
 projects[views_fieldsets][subdir] = civihr-contrib-required
-projects[views_fieldsets][version] = "1.2"
+projects[views_fieldsets][version] = "2.1"
 
 projects[options_element][subdir] = civihr-contrib-required
 projects[options_element][version] = "1.12"


### PR DESCRIPTION
## Overview
Staging and demo servers were showing HTML code on /hr-resources view on attachment list for each resource.

![image](https://user-images.githubusercontent.com/21999940/28209019-4e05d624-6856-11e7-92ef-4997e74007ec.png)

## Before
Staging and demo servers were using the latest version of Visits_fieldsets module, which was incompatible with the template being used to render the HTML for the attachment list.

## After
Updated the original template so it's compatible with v2.1 of Views fieldset (see https://github.com/compucorp/civihr-employee-portal-theme/pull/188). Replaced v1.2 for v2.1 in drush makefile, so that now new installations use the latest version of the module.

![image](https://user-images.githubusercontent.com/21999940/28209140-d2c2ba8a-6856-11e7-92e4-f43f97a360e9.png)
