### PR TITLE
PCHR-2426: Update Shoreditch and Styleguide repos and make Drush required

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In order to run the script and CiviHR you'll need:
 - MySQL 5.5 or 5.6
 - Git
 - Curl
-- Drush >= 7 (the script will download this automatically if not present, but if you already have drush installed, make sure it's this minimum required version)
+- Drush >= 7 (Available globally)
 
 You'll also need to enable URL rewriting on your web server.
 
@@ -102,7 +102,6 @@ For easier understanding upgrade scripts are split into 3 parts.
 - POST RELEASE which takes care of any new configurations that need to be made after upgrades
 
 Upgrade scripts can be found in upgrade-scripts folder. They must be run from web root folder of the site, not any of it subdirs due to depending on relative paths to run git updates.
-
 
 Known Issues and Limitations
 ----------------------------

--- a/civihr-install
+++ b/civihr-install
@@ -716,10 +716,8 @@ civihr_parse_options "$@"
 
 # Checking for Git dependencies.
 command -v git >/dev/null 2>&1 || { echo "Please download git to continue."; exit 1; }
-# Checking for Drush dependencies if not present downloading into temp.
-command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar" && chmod +x "$TMPDIR/drush" )
-# Adding Drush to environment path.
-[[ -f "$TMPDIR/drush" ]] && export PATH="$TMPDIR:$PATH"
+# Checking for Drush dependencies.
+command -v drush >/dev/null 2>&1 || { echo "Please download drush to continue."; exit 1; }
 
 ##########################################################
 # Downloads Drupal, CiviCRM and CiviHR from drush.make file.

--- a/drush.make
+++ b/drush.make
@@ -244,12 +244,12 @@ libraries[civihr_tasks][overwrite] = TRUE
 
 libraries[org.civicrm.shoreditch][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.shoreditch][download][type] = git
-libraries[org.civicrm.shoreditch][download][url] = https://github.com/compucorp/org.civicrm.shoreditch
+libraries[org.civicrm.shoreditch][download][url] = https://github.com/civicrm/org.civicrm.shoreditch
 libraries[org.civicrm.shoreditch][overwrite] = TRUE
 
 libraries[org.civicrm.styleguide][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.styleguide][download][type] = git
-libraries[org.civicrm.styleguide][download][url] = https://github.com/compucorp/org.civicrm.styleguide
+libraries[org.civicrm.styleguide][download][url] = https://github.com/civicrm/org.civicrm.styleguide
 libraries[org.civicrm.styleguide][overwrite] = TRUE
 
 ; ****************************************

--- a/upgrade-scripts/1.6.10.sh
+++ b/upgrade-scripts/1.6.10.sh
@@ -10,8 +10,8 @@ cd sites/all/modules/civicrm/tools/extensions/civihr && git pull origin master &
 cd sites/all/modules/civicrm/tools/extensions/civihr_tasks && git pull origin master &&  cd -
 cd sites/all/modules/civihr-custom && git pull origin master &&  cd -
 cd sites/all/themes/civihr_employee_portal_theme && git pull origin master &&  cd -
-cd sites/all/modules/civicrm/tools/extensions/org.civicrm.styleguide/ && git pull origin master &&  cd -
-cd sites/all/modules/civicrm/tools/extensions/org.civicrm.shoreditch/ && git pull origin master &&  cd -
+cd sites/all/modules/civicrm/tools/extensions/org.civicrm.styleguide/ && git remote set-url origin https://github.com/civicrm/org.civicrm.shoreditch.git && git fetch origin && git checkout master &&  cd -
+cd sites/all/modules/civicrm/tools/extensions/org.civicrm.shoreditch/ && git remote set-url origin https://github.com/civicrm/org.civicrm.shoreditch.git && git fetch origin && git checkout master &&  cd -
 drush cvapi extension.refresh local=1
 drush updatedb -y
 drush cvapi extension.upgrade -y


### PR DESCRIPTION
The installer was pulling the code for Shoreditch and the Styleguide from Compucorp's forks, which don't have a `master` branch that is required by the upgrade script (it pulls changes from that branch). In order to 
avoid errors during an upgrade, the installer was updated to use the original repositories instead. The upgrade script was also updated to make of updating existing sites and point them to the original repositories as well.

The upgrade script assumes that Drush will be available globally, so this PR also includes a change to make sure of that. The script was updated to stop the installation if Drush isn't available.