### PR TITLE
PCHR-2632: Add menu_attributes module

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -199,6 +199,9 @@ projects[conditional_styles][version] = 2.2
 projects[smtp][subdir] = civihr-contrib-required
 projects[smtp][version] = 1.6
 
+projects[menu_attributes][subdir] = civihr-contrib-required
+projects[menu_attributes][version] = 1.0
+
 ; ****************************************
 ; Compucorp custom drupal modules
 ; ****************************************
@@ -225,7 +228,7 @@ libraries[civihr_employee_portal_theme][download][branch] = master
 libraries[civihr_employee_portal_theme][overwrite] = TRUE
 
 ; ****************************************
-; Boostrap theme
+; Bootstrap theme
 ; ****************************************
 
 ; Download Radix base theme


### PR DESCRIPTION
This PR adds the [menu_attributes](https://www.drupal.org/project/menu_attributes) module to CiviHR, that we need so we can assign an icon to each of the main menu items

cc @davialexandre 