### PR TITLE
PCHR-2632: Add menu_per_role module

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -202,6 +202,9 @@ projects[smtp][version] = 1.6
 projects[menu_attributes][subdir] = civihr-contrib-required
 projects[menu_attributes][version] = 1.0
 
+projects[menu_per_role][subdir] = civihr-contrib-required
+projects[menu_per_role][version] = 1.0-alpha1
+
 ; ****************************************
 ; Compucorp custom drupal modules
 ; ****************************************


### PR DESCRIPTION
This PR adds the [menu_per_role](https://www.drupal.org/project/menu_per_role) module to CiviHR, so that we can assign access criteria also to menu items that are pointing to external URLs
