### PR TITLE
PCHR-2959: Enable on install menu_attributes and menu_per_role

### DIFF
--- a/civihr-install
+++ b/civihr-install
@@ -853,7 +853,7 @@ function civihr_install_site(){
 
     drush -y updatedb
     drush -y dis overlay shortcut color
-    drush -y en administerusersbyrole role_delegation civicrm toolbar locale seven userprotect masquerade smtp yoti
+    drush -y en administerusersbyrole role_delegation civicrm toolbar locale seven userprotect masquerade smtp yoti menu_attributes menu_per_role
 
     install_civihr
 


### PR DESCRIPTION
_(nevermind the name of the branch with the wrong ticket number, the correct ticket was created after the PR)_

In #10 and #11  we added the [menu_attributes](https://www.drupal.org/project/menu_attributes) and [menu_per_role](https://www.drupal.org/project/menu_per_role) modules to CiviHR, but forgot to enable them on install