### PR TITLE
PCHR-2961: User roles_for_menu instead of menus_per_role module

### DIFF
--- a/civihr-install
+++ b/civihr-install
@@ -853,7 +853,7 @@ function civihr_install_site(){
 
     drush -y updatedb
     drush -y dis overlay shortcut color
-    drush -y en administerusersbyrole role_delegation civicrm toolbar locale seven userprotect masquerade smtp yoti menu_attributes menu_per_role
+    drush -y en administerusersbyrole role_delegation civicrm toolbar locale seven userprotect masquerade smtp yoti menu_attributes roles_for_menu
 
     install_civihr
 

--- a/drush.make
+++ b/drush.make
@@ -202,8 +202,8 @@ projects[smtp][version] = 1.6
 projects[menu_attributes][subdir] = civihr-contrib-required
 projects[menu_attributes][version] = 1.0
 
-projects[menu_per_role][subdir] = civihr-contrib-required
-projects[menu_per_role][version] = 1.0-alpha1
+projects[roles_for_menu][subdir] = civihr-contrib-required
+projects[roles_for_menu][version] = 1.1
 
 ; ****************************************
 ; Compucorp custom drupal modules


### PR DESCRIPTION
The [menu_per_role](https://www.drupal.org/project/menu_per_role) module doesn't allow settings to be exported in features, while [roles_for_menu](https://www.drupal.org/project/roles_for_menu) does. Hence the switch