### PR TITLE
PCHR-3484: 1.7.5 updates

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -27,7 +27,7 @@ libraries[civihr][destination] = modules
 libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
 libraries[civihr][download][type] = git
 libraries[civihr][download][url] = https://github.com/civicrm/civihr.git
-libraries[civihr][download][tag] = 1.7.4
+libraries[civihr][download][tag] = 1.7.5
 libraries[civihr][overwrite] = TRUE
 
 ; ****************************************
@@ -51,7 +51,7 @@ projects[webform_civicrm][version] = "4.19"
 projects[webform_civicrm][patch][] = "https://patch-diff.githubusercontent.com/raw/colemanw/webform_civicrm/pull/93.patch"
 
 projects[views][subdir] = contrib
-projects[views][version] = 3.14
+projects[views][version] = 3.18
 projects[views][patch][] = "https://www.drupal.org/files/issues/views-exposed_forms_ajax_support-1183418-73.patch"
 
 projects[userprotect][subdir] = contrib
@@ -75,7 +75,7 @@ projects[date][subdir] = civihr-contrib-required
 projects[date][version] = "2.8"
 
 projects[entity][subdir] = civihr-contrib-required
-projects[entity][version] = "1.6"
+projects[entity][version] = "1.9"
 
 projects[civicrm_entity][subdir] = civihr-contrib-required
 projects[civicrm_entity][version] = "2.x-dev"
@@ -192,7 +192,7 @@ projects[conditional_styles][version] = 2.2
 
 ; SMTP Module
 projects[smtp][subdir] = civihr-contrib-required
-projects[smtp][version] = 1.6
+projects[smtp][version] = 1.7
 
 projects[menu_attributes][subdir] = civihr-contrib-required
 projects[menu_attributes][version] = 1.0
@@ -211,7 +211,7 @@ libraries[civihr_employee_portal][destination] = modules
 libraries[civihr_employee_portal][directory_name] = civihr-custom
 libraries[civihr_employee_portal][download][type] = git
 libraries[civihr_employee_portal][download][url] = https://github.com/compucorp/civihr-employee-portal
-libraries[civihr_employee_portal][download][tag] = 1.7.4
+libraries[civihr_employee_portal][download][tag] = 1.7.5
 libraries[civihr_employee_portal][overwrite] = TRUE
 
 ; ****************************************
@@ -225,7 +225,7 @@ projects[radix][version] = "3.4"
 libraries[civihr_employee_portal_theme][destination] = themes
 libraries[civihr_employee_portal_theme][download][type] = git
 libraries[civihr_employee_portal_theme][download][url] = https://github.com/compucorp/civihr-employee-portal-theme
-libraries[civihr_employee_portal_theme][download][tag] = 1.7.4
+libraries[civihr_employee_portal_theme][download][tag] = 1.7.5
 libraries[civihr_employee_portal_theme][overwrite] = TRUE
 
 ; ****************************************
@@ -242,7 +242,7 @@ projects[bootstrap][version] = "3.1"
 libraries[civihr_tasks][destination] = modules/civicrm/tools/extensions
 libraries[civihr_tasks][download][type] = git
 libraries[civihr_tasks][download][url] = https://github.com/compucorp/civihr-tasks-assignments
-libraries[civihr_tasks][download][tag] = 1.7.4
+libraries[civihr_tasks][download][tag] = 1.7.5
 libraries[civihr_tasks][overwrite] = TRUE
 
 ; ****************************************
@@ -252,13 +252,13 @@ libraries[civihr_tasks][overwrite] = TRUE
 libraries[org.civicrm.shoreditch][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.shoreditch][download][type] = git
 libraries[org.civicrm.shoreditch][download][url] = https://github.com/civicrm/org.civicrm.shoreditch
-libraries[org.civicrm.shoreditch][download][tag] = 0.1-alpha16
+libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha17
 libraries[org.civicrm.shoreditch][overwrite] = TRUE
 
 libraries[org.civicrm.styleguide][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.styleguide][download][type] = git
 libraries[org.civicrm.styleguide][download][url] = https://github.com/civicrm/org.civicrm.styleguide
-libraries[org.civicrm.atyleguide][download][tag] = 0.1-alpha3
+libraries[org.civicrm.atyleguide][download][tag] = v0.1-alpha4
 libraries[org.civicrm.styleguide][overwrite] = TRUE
 
 ; ****************************************

--- a/upgrade-scripts/1.7.5.sh
+++ b/upgrade-scripts/1.7.5.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "Installing security updates"
+drush up --security-only -y
+
+echo "Pulling CiviHR 1.7.5"
+cd sites/all/modules/civicrm/tools/extensions/civihr && git stash && git fetch origin && git checkout 1.7.5 && cd -
+cd sites/all/modules/civicrm/tools/extensions/civihr_tasks && git stash && git fetch origin && git checkout 1.7.5 && cd -
+cd sites/all/modules/civihr-custom && git stash && git fetch origin && git checkout 1.7.5 && cd -
+cd sites/all/themes/civihr_employee_portal_theme && git stash && git fetch origin && git checkout 1.7.5 && cd -
+cd sites/all/modules/civicrm/tools/extensions/org.civicrm.styleguide/ && git stash && git fetch origin && git checkout v0.1-alpha4 && cd -
+cd sites/all/modules/civicrm/tools/extensions/org.civicrm.shoreditch/ && git stash && git fetch origin && git checkout v0.1-alpha17 && cd -
+
+drush cvapi extension.upgrade -y
+drush updatedb -y
+
+drush vr civihr_report_people -y
+drush vr civihr_report_leave_and_absence -y
+
+drush cc all
+drush cc civicrm


### PR DESCRIPTION
Includes:

- Updates to the installation script to download CiviHR 1.7.5 from the repositories
- Security updates of some Drupal modules