### PR TITLE
PCHR-3619: Only apply fork patch if script exists

### DIFF
--- a/civihr-install
+++ b/civihr-install
@@ -794,7 +794,12 @@ function _civihr_disabled_unused_blocks() {
 # Runs the scripts that patches the compucorp's civicrm-core fork on
 # the original core files
 function apply_core_fork_patch() {
-  (cd ${CIVI_CORE}/tools/extensions/civihr && bash bin/apply-core-fork-patch.sh)
+  pushd "${CIVI_CORE}/tools/extensions/civihr" >> /dev/null
+    APPLY_FOR_SCRIPT=bin/apply-core-fork-patch.sh
+    if [ -e ${APPLY_FOR_SCRIPT} ]; then
+        bash ${APPLY_FOR_SCRIPT}
+    fi;
+  popd
 }
 
 ##########################################################


### PR DESCRIPTION
### Problem
On https://github.com/compucorp/civihr-installer/pull/22 we started using a script to apply civicrm core patches from our fork. That script will only be included in the next CiviHR release (1.7.6). So, if someone tries to install the CiviHR version available today (1.7.5) it will not find the patch application script and the installation will fail

### Solution
Checking for the existence of the script to apply the patches before calling it.