### PR TITLE
PCHR-3641: CiviHR 1.7.6 updates

### DIFF
--- a/civihr-install
+++ b/civihr-install
@@ -885,6 +885,9 @@ function civihr_install_site(){
 
     drush vset --format=integer node_export_reset_path_webform 0
 
+    ## Disable error logging in Drupal
+    drush vset -y error_level 0
+
     ## Mail settings
     drush vset --format=integer mimemail_sitestyle 0
     drush vset --format=integer smtp_allowhtml 1

--- a/drush.make
+++ b/drush.make
@@ -47,8 +47,7 @@ projects[webform][subdir] = contrib
 projects[webform][version] = 4.12
 
 projects[webform_civicrm][subdir] = contrib
-projects[webform_civicrm][version] = "4.19"
-projects[webform_civicrm][patch][] = "https://patch-diff.githubusercontent.com/raw/colemanw/webform_civicrm/pull/93.patch"
+projects[webform_civicrm][version] = "4.20"
 
 projects[views][subdir] = contrib
 projects[views][version] = 3.18

--- a/drush.make
+++ b/drush.make
@@ -27,7 +27,7 @@ libraries[civihr][destination] = modules
 libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
 libraries[civihr][download][type] = git
 libraries[civihr][download][url] = https://github.com/civicrm/civihr.git
-libraries[civihr][download][tag] = 1.7.5
+libraries[civihr][download][tag] = 1.7.6
 libraries[civihr][overwrite] = TRUE
 
 ; ****************************************
@@ -210,7 +210,7 @@ libraries[civihr_employee_portal][destination] = modules
 libraries[civihr_employee_portal][directory_name] = civihr-custom
 libraries[civihr_employee_portal][download][type] = git
 libraries[civihr_employee_portal][download][url] = https://github.com/compucorp/civihr-employee-portal
-libraries[civihr_employee_portal][download][tag] = 1.7.5
+libraries[civihr_employee_portal][download][tag] = 1.7.6
 libraries[civihr_employee_portal][overwrite] = TRUE
 
 ; ****************************************
@@ -224,7 +224,7 @@ projects[radix][version] = "3.4"
 libraries[civihr_employee_portal_theme][destination] = themes
 libraries[civihr_employee_portal_theme][download][type] = git
 libraries[civihr_employee_portal_theme][download][url] = https://github.com/compucorp/civihr-employee-portal-theme
-libraries[civihr_employee_portal_theme][download][tag] = 1.7.5
+libraries[civihr_employee_portal_theme][download][tag] = 1.7.6
 libraries[civihr_employee_portal_theme][overwrite] = TRUE
 
 ; ****************************************
@@ -241,7 +241,7 @@ projects[bootstrap][version] = "3.1"
 libraries[civihr_tasks][destination] = modules/civicrm/tools/extensions
 libraries[civihr_tasks][download][type] = git
 libraries[civihr_tasks][download][url] = https://github.com/compucorp/civihr-tasks-assignments
-libraries[civihr_tasks][download][tag] = 1.7.5
+libraries[civihr_tasks][download][tag] = 1.7.6
 libraries[civihr_tasks][overwrite] = TRUE
 
 ; ****************************************
@@ -251,13 +251,13 @@ libraries[civihr_tasks][overwrite] = TRUE
 libraries[org.civicrm.shoreditch][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.shoreditch][download][type] = git
 libraries[org.civicrm.shoreditch][download][url] = https://github.com/civicrm/org.civicrm.shoreditch
-libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha17
+libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha18
 libraries[org.civicrm.shoreditch][overwrite] = TRUE
 
 libraries[org.civicrm.styleguide][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.styleguide][download][type] = git
 libraries[org.civicrm.styleguide][download][url] = https://github.com/civicrm/org.civicrm.styleguide
-libraries[org.civicrm.atyleguide][download][tag] = v0.1-alpha4
+libraries[org.civicrm.atyleguide][download][tag] = v0.1-alpha5
 libraries[org.civicrm.styleguide][overwrite] = TRUE
 
 ; ****************************************

--- a/upgrade-scripts/1.7.6.sh
+++ b/upgrade-scripts/1.7.6.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "Installing security updates"
+drush up --security-only -y
+
+echo "Creating core-fork-last-commit-patched.txt and make it skip the attachments patch"
+
+pushd "sites/all/modules/civicrm/tools/extensions/civihr" >> /dev/null
+    if [ ! -f core-fork-last-commit-patched.txt ]; then
+        echo "985964d12dd9fd046d53d2923aa0ed4bf928764c" > core-fork-last-commit-patched.txt
+    fi;
+popd
+
+echo "Pulling CiviHR 1.7.6"
+cd sites/all/modules/civicrm/tools/extensions/civihr && git stash && git fetch origin && git checkout 1.7.6 && cd -
+cd sites/all/modules/civicrm/tools/extensions/civihr_tasks && git stash && git fetch origin && git checkout 1.7.6 && cd -
+cd sites/all/modules/civihr-custom && git stash && git fetch origin && git checkout 1.7.6 && cd -
+cd sites/all/themes/civihr_employee_portal_theme && git stash && git fetch origin && git checkout 1.7.6 && cd -
+cd sites/all/modules/civicrm/tools/extensions/org.civicrm.styleguide/ && git stash && git fetch origin && git checkout v0.1-alpha5 && cd -
+cd sites/all/modules/civicrm/tools/extensions/org.civicrm.shoreditch/ && git stash && git fetch origin && git checkout v0.1-alpha18 && cd -
+
+echo "Patching compucorp:civicrm-core on top of core files"
+cd sites/all/modules/civicrm/tools/extensions/civihr && bin/apply-core-fork-patch.sh && cd -
+
+drush cvapi extension.upgrade -y
+drush updatedb -y
+
+drush pm-update -y webform_civicrm
+
+drush cc all
+drush cc civicrm


### PR DESCRIPTION
This update includes:

- Update the CiviHR, Shoreditch and Styleguide versions used when creating a new site
- Add the upgrade script for CiviHR 1.7.6
- Update webform_civicrm to 4.20 to remove the patch we have been using on 4.19
- Add a new extra configuration to disable error logging on Drupal. This hides Notices and Warnings on Drupal. As it's possible to see on  /admin/config/development/logging, this is a recommended configuration for production sites. On dev sites, created with buildkit, the errors will still be displayed so that developers will be able to see and fix them

