### PR TITLE
PCHR-3811: Update CiviHR repo URL

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -26,7 +26,7 @@ libraries[civicrm][download][url] = "https://download.civicrm.org/civicrm-4.7.27
 libraries[civihr][destination] = modules
 libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
 libraries[civihr][download][type] = git
-libraries[civihr][download][url] = https://github.com/civicrm/civihr.git
+libraries[civihr][download][url] = https://github.com/compucorp/civihr.git
 libraries[civihr][download][tag] = 1.7.7
 libraries[civihr][overwrite] = TRUE
 


### PR DESCRIPTION
## Overview

The ownership of the civihr repository has been transferred from the CiviCRM organization to Compucorp. This PR updates references to the repo URL to reflect the new ownership.

## Before

URLs to the repository would reference `civicrm` as the owner.

## After

URLs to the repository now reference `compucorp` as the owner.