### PR TITLE
PCHR-3855: Add google_tag and datalayer modules

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -202,6 +202,12 @@ projects[roles_for_menu][version] = 1.1
 projects[views_slideshow][subdir] = civihr-contrib-required
 projects[views_slideshow][version] = 3.9
 
+projects[google_tag][subdir] = civihr-contrib-required
+projects[google_tag][version] = 1.3
+
+projects[datalayer][subdir] = civihr-contrib-required
+projects[datalayer][version] = 1.1
+
 ; ****************************************
 ; Compucorp custom drupal modules
 ; ****************************************


### PR DESCRIPTION
Adding the [google_tag](https://www.drupal.org/project/google_tag) and [dalayer](https://www.drupal.org/project/datalayer) modules to the installer