### PR TITLE
PCHR-4119: CiviHR 1.7.10 updates

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -27,7 +27,7 @@ libraries[civihr][destination] = modules
 libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
 libraries[civihr][download][type] = git
 libraries[civihr][download][url] = https://github.com/compucorp/civihr.git
-libraries[civihr][download][tag] = 1.7.9
+libraries[civihr][download][tag] = 1.7.10
 libraries[civihr][overwrite] = TRUE
 
 ; ****************************************
@@ -216,7 +216,7 @@ libraries[civihr_employee_portal][destination] = modules
 libraries[civihr_employee_portal][directory_name] = civihr-custom
 libraries[civihr_employee_portal][download][type] = git
 libraries[civihr_employee_portal][download][url] = https://github.com/compucorp/civihr-employee-portal
-libraries[civihr_employee_portal][download][tag] = 1.7.9
+libraries[civihr_employee_portal][download][tag] = 1.7.10
 libraries[civihr_employee_portal][overwrite] = TRUE
 
 ; ****************************************
@@ -230,7 +230,7 @@ projects[radix][version] = "3.4"
 libraries[civihr_employee_portal_theme][destination] = themes
 libraries[civihr_employee_portal_theme][download][type] = git
 libraries[civihr_employee_portal_theme][download][url] = https://github.com/compucorp/civihr-employee-portal-theme
-libraries[civihr_employee_portal_theme][download][tag] = 1.7.9
+libraries[civihr_employee_portal_theme][download][tag] = 1.7.10
 libraries[civihr_employee_portal_theme][overwrite] = TRUE
 
 ; ****************************************
@@ -247,7 +247,7 @@ projects[bootstrap][version] = "3.1"
 libraries[civihr_tasks][destination] = modules/civicrm/tools/extensions
 libraries[civihr_tasks][download][type] = git
 libraries[civihr_tasks][download][url] = https://github.com/compucorp/civihr-tasks-assignments
-libraries[civihr_tasks][download][tag] = 1.7.9
+libraries[civihr_tasks][download][tag] = 1.7.10
 libraries[civihr_tasks][overwrite] = TRUE
 
 ; ****************************************
@@ -257,13 +257,13 @@ libraries[civihr_tasks][overwrite] = TRUE
 libraries[org.civicrm.shoreditch][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.shoreditch][download][type] = git
 libraries[org.civicrm.shoreditch][download][url] = https://github.com/civicrm/org.civicrm.shoreditch
-libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha21
+libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha24
 libraries[org.civicrm.shoreditch][overwrite] = TRUE
 
 libraries[org.civicrm.styleguide][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.styleguide][download][type] = git
 libraries[org.civicrm.styleguide][download][url] = https://github.com/civicrm/org.civicrm.styleguide
-libraries[org.civicrm.atyleguide][download][tag] = v0.1-alpha5
+libraries[org.civicrm.atyleguide][download][tag] = v0.1-alpha6
 libraries[org.civicrm.styleguide][overwrite] = TRUE
 
 ; ****************************************

--- a/upgrade-scripts/1.7.10.sh
+++ b/upgrade-scripts/1.7.10.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+echo "Installing security updates"
+drush up --security-only -y
+
+echo "Pulling CiviHR 1.7.10"
+cd sites/all/modules/civicrm/tools/extensions/civihr && git stash && git fetch origin && git checkout 1.7.10 && cd -
+cd sites/all/modules/civicrm/tools/extensions/civihr_tasks && git stash && git fetch origin && git checkout 1.7.10 && cd -
+cd sites/all/modules/civihr-custom && git stash && git fetch origin && git checkout 1.7.10 && cd -
+cd sites/all/themes/civihr_employee_portal_theme && git stash && git fetch origin && git checkout 1.7.10 && cd -
+cd sites/all/modules/civicrm/tools/extensions/org.civicrm.styleguide/ && git stash && git fetch origin && git checkout v0.1-alpha6 && cd -
+cd sites/all/modules/civicrm/tools/extensions/org.civicrm.shoreditch/ && git stash && git fetch origin && git checkout v0.1-alpha24 && cd -
+
+# When logging is enabled, the upgrader 1023 in HRCore fails,
+# because civi will try to recreate triggers for the deleted
+# fields in that upgrader. When logging is disabled, the
+# triggers are not rebuilt
+drush cvapi setting.create logging=0
+
+drush cvapi extension.upgrade -y
+drush updatedb -y
+
+# Now that the upgrader has been applied, we can enable logging again
+drush cvapi setting.create logging=1
+
+drush fr civihr_employee_portal_features.menu_links -y
+
+drush cc all
+drush cc civicrm


### PR DESCRIPTION
This PR:
- Updates CiviHR repos version to 1.7.10
- Updates Styleguide to v0.1-alpha6
- Updates Shoreditch to v0.1-alpha24
- Add the upgrade script for CiviHR 1.7.10
