### PR TITLE
PCHR-4181: CiviHR 1.7.11 updates

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -27,7 +27,7 @@ libraries[civihr][destination] = modules
 libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
 libraries[civihr][download][type] = git
 libraries[civihr][download][url] = https://github.com/compucorp/civihr.git
-libraries[civihr][download][tag] = 1.7.10
+libraries[civihr][download][tag] = 1.7.11
 libraries[civihr][overwrite] = TRUE
 
 ; ****************************************
@@ -216,7 +216,7 @@ libraries[civihr_employee_portal][destination] = modules
 libraries[civihr_employee_portal][directory_name] = civihr-custom
 libraries[civihr_employee_portal][download][type] = git
 libraries[civihr_employee_portal][download][url] = https://github.com/compucorp/civihr-employee-portal
-libraries[civihr_employee_portal][download][tag] = 1.7.10
+libraries[civihr_employee_portal][download][tag] = 1.7.11
 libraries[civihr_employee_portal][overwrite] = TRUE
 
 ; ****************************************
@@ -230,7 +230,7 @@ projects[radix][version] = "3.4"
 libraries[civihr_employee_portal_theme][destination] = themes
 libraries[civihr_employee_portal_theme][download][type] = git
 libraries[civihr_employee_portal_theme][download][url] = https://github.com/compucorp/civihr-employee-portal-theme
-libraries[civihr_employee_portal_theme][download][tag] = 1.7.10
+libraries[civihr_employee_portal_theme][download][tag] = 1.7.11
 libraries[civihr_employee_portal_theme][overwrite] = TRUE
 
 ; ****************************************
@@ -247,7 +247,7 @@ projects[bootstrap][version] = "3.1"
 libraries[civihr_tasks][destination] = modules/civicrm/tools/extensions
 libraries[civihr_tasks][download][type] = git
 libraries[civihr_tasks][download][url] = https://github.com/compucorp/civihr-tasks-assignments
-libraries[civihr_tasks][download][tag] = 1.7.10
+libraries[civihr_tasks][download][tag] = 1.7.11
 libraries[civihr_tasks][overwrite] = TRUE
 
 ; ****************************************
@@ -257,7 +257,7 @@ libraries[civihr_tasks][overwrite] = TRUE
 libraries[org.civicrm.shoreditch][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.shoreditch][download][type] = git
 libraries[org.civicrm.shoreditch][download][url] = https://github.com/civicrm/org.civicrm.shoreditch
-libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha24
+libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha25
 libraries[org.civicrm.shoreditch][overwrite] = TRUE
 
 libraries[org.civicrm.styleguide][destination] = modules/civicrm/tools/extensions

--- a/upgrade-scripts/1.7.11.sh
+++ b/upgrade-scripts/1.7.11.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+echo "Installing security updates"
+drush up --security-only -y
+
+CIVIHRVER=1.7.11
+
+echo "Pulling CiviHR $CIVIHRVER"
+
+function update_repo() {
+  pushd $1
+  git stash 2> /dev/null &&
+  git fetch origin 2> /dev/null &&
+  git checkout $2 2> /dev/null &&
+  git log --oneline -n 1
+  popd
+}
+
+update_repo sites/all/modules/civicrm/tools/extensions/civihr $CIVIHRVER
+update_repo sites/all/modules/civicrm/tools/extensions/civihr_tasks $CIVIHRVER
+update_repo sites/all/modules/civihr-custom $CIVIHRVER
+update_repo sites/all/themes/civihr_employee_portal_theme $CIVIHRVER
+update_repo sites/all/modules/civicrm/tools/extensions/org.civicrm.styleguide v0.1-alpha6
+update_repo sites/all/modules/civicrm/tools/extensions/org.civicrm.shoreditch v0.1-alpha25
+
+echo "PCHR-4238: Fix Relationship Type in XML definitions"
+cat <<"SCRIPT" > fix-4238.php
+<?php
+    civicrm_initialize();
+
+    $caseTypes = civicrm_api3('CaseType', 'get', [
+      'return' => ['id', 'name'],
+      'sequential' => 1
+    ])['values'];
+
+    foreach ($caseTypes as $caseType) {
+      $xml = CRM_Case_XMLRepository::singleton()->retrieve($caseType['name']);
+      $updated = false;
+      if($xml) {
+        foreach ($xml->CaseRoles->RelationshipType as $rt) {
+          if ($rt->name == 'Line Manager') {
+            $rt->name = 'Is Line Manager of';
+            $updated = true;
+          }
+        }
+      }
+
+      if ($updated) {
+        // We update the table directly because using the API would result in the
+        // creation of managed entities for the CaseType components, which we
+        // don't want to happen
+        $params = [
+          1 => [$xml->asXML(), 'String'],
+          2 => [$caseType['id'], 'Integer']
+        ];
+        CRM_Core_DAO::executeQuery("UPDATE civicrm_case_type SET definition = %1 WHERE id = %2", $params);
+      }
+    }
+SCRIPT
+drush php-script fix-4238
+rm -f fix-4238
+
+echo "FAR-298: Enable CiviTask and CiviDocument for all sites"
+drush ev "\$components = civicrm_api3('setting', 'getsingle', ['return' => 'enable_components', 'sequential' => 1]); \$components = array_unique(array_merge(\$components['enable_components'], ['CiviTask', 'CiviDocument'])); var_dump(civicrm_api3('setting', 'create', ['enable_components' => \$components]));"
+
+echo "PCHR-4138: Revert menus in the SSP"
+drush features-revert civihr_employee_portal_features.menu_links -y
+
+echo "PCHR-4233: Remove orphan managed CiviCase activity types"
+drush civicrm-sql-query "delete from civicrm_managed where module = 'civicrm' and name like 'civicase:%' and entity_id not in (select id from civicrm_option_value)"
+drush civicrm-sql-query "select * from civicrm_managed where module = 'civicrm' and name like 'civicase:%' and entity_id not in (select id from civicrm_option_value)"
+
+drush cvapi extension.upgrade -y
+drush updatedb -y
+
+drush cc all
+drush cc civicrm


### PR DESCRIPTION
## Overview

- Bump the extension and module versions in the `drush.make` file to `1.7.11`
- Add an upgrade script to upgrade existing sites from `1.7.10` to `1.7.11`

## Technical Details

The code in upgrade script was slightly refactored to avoid the duplication we had before. Previously, the code would look like this:

```bash
cd sites/all/modules/civicrm/tools/extensions/civihr && git stash && git fetch origin && git checkout 1.7.10 && cd -
cd sites/all/modules/civicrm/tools/extensions/civihr_tasks && git stash && git fetch origin && git checkout 1.7.10 && cd -
cd sites/all/modules/civihr-custom && git stash && git fetch origin && git checkout 1.7.10 && cd -
cd sites/all/themes/civihr_employee_portal_theme && git stash && git fetch origin && git checkout 1.7.10 && cd -
cd sites/all/modules/civicrm/tools/extensions/org.civicrm.styleguide/ && git stash && git fetch origin && git checkout v0.1-alpha6 && cd -
cd sites/all/modules/civicrm/tools/extensions/org.civicrm.shoreditch/ && git stash && git fetch origin && git checkout v0.1-alpha24 && cd -
```

Note how this is a sequence of duplicated commands where only the folder the tag to be checked out differ. 

As part of the refactoring, everything was moved to an `update_repo` function:

```bash
function update_repo() {
  pushd $1
  git stash 2> /dev/null &&
  git fetch origin 2> /dev/null &&
  git checkout $2 2> /dev/null &&
  git log --oneline -n 1
  popd
}
```

And now, for each repo, we just do something like:

```bash
update_repo <REPO FOLDER> <TAG>
```

Note that we're now also redirecting the err output of the git commands to `/dev/null`. The reason is that this output is not really useful in the vast majority of the cases and it only adds noise to the script output. Finally a `git log --oneline -n 1` command was added after each upgrade to show the commit hash the repo will be left pointing to, so what we can easily spot if it's pointing to the right branch or not.