### PR TITLE
PCHR-4455: CiviHR 1.7.14 updates

### DIFF
--- a/drush.make
+++ b/drush.make
@@ -27,7 +27,7 @@ libraries[civihr][destination] = modules
 libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
 libraries[civihr][download][type] = git
 libraries[civihr][download][url] = https://github.com/compucorp/civihr.git
-libraries[civihr][download][tag] = 1.7.13
+libraries[civihr][download][tag] = 1.7.14
 libraries[civihr][overwrite] = TRUE
 
 ; ****************************************
@@ -216,7 +216,7 @@ libraries[civihr_employee_portal][destination] = modules
 libraries[civihr_employee_portal][directory_name] = civihr-custom
 libraries[civihr_employee_portal][download][type] = git
 libraries[civihr_employee_portal][download][url] = https://github.com/compucorp/civihr-employee-portal
-libraries[civihr_employee_portal][download][tag] = 1.7.13
+libraries[civihr_employee_portal][download][tag] = 1.7.14
 libraries[civihr_employee_portal][overwrite] = TRUE
 
 ; ****************************************
@@ -230,7 +230,7 @@ projects[radix][version] = "3.4"
 libraries[civihr_employee_portal_theme][destination] = themes
 libraries[civihr_employee_portal_theme][download][type] = git
 libraries[civihr_employee_portal_theme][download][url] = https://github.com/compucorp/civihr-employee-portal-theme
-libraries[civihr_employee_portal_theme][download][tag] = 1.7.13
+libraries[civihr_employee_portal_theme][download][tag] = 1.7.14
 libraries[civihr_employee_portal_theme][overwrite] = TRUE
 
 ; ****************************************
@@ -247,7 +247,7 @@ projects[bootstrap][version] = "3.1"
 libraries[civihr_tasks][destination] = modules/civicrm/tools/extensions
 libraries[civihr_tasks][download][type] = git
 libraries[civihr_tasks][download][url] = https://github.com/compucorp/civihr-tasks-assignments
-libraries[civihr_tasks][download][tag] = 1.7.13
+libraries[civihr_tasks][download][tag] = 1.7.14
 libraries[civihr_tasks][overwrite] = TRUE
 
 ; ****************************************
@@ -257,7 +257,7 @@ libraries[civihr_tasks][overwrite] = TRUE
 libraries[org.civicrm.shoreditch][destination] = modules/civicrm/tools/extensions
 libraries[org.civicrm.shoreditch][download][type] = git
 libraries[org.civicrm.shoreditch][download][url] = https://github.com/civicrm/org.civicrm.shoreditch
-libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha28
+libraries[org.civicrm.shoreditch][download][tag] = v0.1-alpha29
 libraries[org.civicrm.shoreditch][overwrite] = TRUE
 
 libraries[org.civicrm.styleguide][destination] = modules/civicrm/tools/extensions

--- a/upgrade-scripts/1.7.14.sh
+++ b/upgrade-scripts/1.7.14.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+echo "Installing security updates"
+drush up --security-only -y
+
+CIVIHRVER=1.7.14
+
+echo "Pulling CiviHR $CIVIHRVER"
+
+function update_repo() {
+  pushd $1
+  git stash 2> /dev/null &&
+  git fetch origin 2> /dev/null &&
+  git checkout $2 2> /dev/null &&
+  git log --oneline -n 1
+  popd
+}
+
+update_repo sites/all/modules/civicrm/tools/extensions/civihr $CIVIHRVER
+update_repo sites/all/modules/civicrm/tools/extensions/civihr_tasks $CIVIHRVER
+update_repo sites/all/modules/civihr-custom $CIVIHRVER
+update_repo sites/all/themes/civihr_employee_portal_theme $CIVIHRVER
+update_repo sites/all/modules/civicrm/tools/extensions/org.civicrm.styleguide v0.1-alpha7
+update_repo sites/all/modules/civicrm/tools/extensions/org.civicrm.shoreditch v0.1-alpha29
+
+echo "Patching compucorp:civicrm-core on top of core files"
+cd sites/all/modules/civicrm/tools/extensions/civihr && bin/apply-core-fork-patch.sh && cd -
+
+drush cvapi extension.upgrade -y
+drush updatedb -y
+
+drush cc all
+drush cc civicrm


### PR DESCRIPTION
This PR

- Adds a script to upgrade an existing 1.7.13 site to 1.7.14
- Updates the CiviHR dependencies:
  - CiviHR extensions to 1.7.14
  - Shoreditch to 0.1-alpha29

